### PR TITLE
Fix for issue 674

### DIFF
--- a/OpenEmuSystem/OEHIDDeviceParser.m
+++ b/OpenEmuSystem/OEHIDDeviceParser.m
@@ -248,7 +248,7 @@ static BOOL OE_isXboxControllerName(NSString *name)
          [controllerDesc addControlWithIdentifier:identifier name:rep[@"Name"] event:genericEvent valueRepresentations:rep[@"Values"]];
      }];
 
-    [genericDesktopElements enumerateObjectsWithOptions:NSEnumerationConcurrent | NSEnumerationReverse usingBlock:
+    [genericDesktopElements enumerateObjectsWithOptions: NSEnumerationReverse usingBlock:
      ^(id elem, NSUInteger idx, BOOL *stop)
      {
          if([OEHIDEvent OE_eventWithElement:(__bridge IOHIDElementRef)elem value:0] == nil)


### PR DESCRIPTION
By poking around a bit, the NSEnumerationConcurrent flag was causing bad index issues when removing objects from genericDesktopElements. I'm not sure this is the best way to fix the issue not being that familiar with the codebase, but it does stop the crashing.
