### PR TITLE
Instead of cluttering the "OpenEmu" folder, core support folders are stored in a folder named "Core Support".

### DIFF
--- a/OpenEmuBase/OEGameCoreController.m
+++ b/OpenEmuBase/OEGameCoreController.m
@@ -63,8 +63,9 @@ NSString *OEEventNamespaceKeys[] = { @"", @"OEGlobalNamespace", @"OEKeyboardName
         NSArray  *paths = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES);
         NSString *basePath = ([paths count] > 0) ? [paths objectAtIndex:0] : NSTemporaryDirectory();
 
-        NSString *supportFolder = [basePath stringByAppendingPathComponent:@"OpenEmu"];
-        _supportDirectoryPath   = [supportFolder stringByAppendingPathComponent:_pluginName];
+        NSString *supportFolder     = [basePath stringByAppendingPathComponent:@"OpenEmu"];
+        NSString *coreSupportFolder = [supportFolder stringByAppendingPathComponent:@"Core Support"];
+        _supportDirectoryPath       = [coreSupportFolder stringByAppendingPathComponent:_pluginName];
 
         _gameDocuments = [[NSMutableArray alloc] init];
     }


### PR DESCRIPTION
# OpenEmu Directory Structure

**Old:** Can get extremely messy with multiple cores.
![screen shot 2013-06-30 at 6 18 15 pm](https://f.cloud.github.com/assets/587915/728143/2f79b1ca-e1ec-11e2-864d-4d62e34122c4.png)

**New** Core support folders are stored in one directory, leaving the OpenEmu directory clean and simple to navigate.
![screen shot 2013-06-30 at 6 17 52 pm](https://f.cloud.github.com/assets/587915/728144/2fe20310-e1ec-11e2-84cf-457293e78c9e.png)
# Compatibility Fix

Due to the path to core support directories being changed, certain core configuration options and/or battery saves will no longer be located and used. To fix the above issue, you can move the directories named after cores in "~/Library/Application Support/OpenEmu/" to "~/Library/Application
Support/OpenEmu/Core Support/" or you can run the sh script located at http://d.pr/n/H9M5. If you choose to run the sh script, please note that if there are any folders that are not generated by OpenEmu located in the OpenEmu folder, they will be moved to the Core Support folder.
