### PR TITLE
Patch to fix non-functional buttons on some third-party game controllers

### DIFF
--- a/OpenEmuSystem/NSResponder+OEHIDAdditions.m
+++ b/OpenEmuSystem/NSResponder+OEHIDAdditions.m
@@ -48,6 +48,7 @@ static dispatch_queue_t oehid_queue;
                     [self triggerPull:anEvent];
                 break;
             case OEHIDEventTypeButton :
+            case OEHIDEventTypeSpecialButton :
                 if([anEvent hasOffState])
                     [self buttonUp:anEvent];
                 else

--- a/OpenEmuSystem/OEControlDescription.m
+++ b/OpenEmuSystem/OEControlDescription.m
@@ -52,6 +52,9 @@ static NSString *OEControlGenericIdentifierFromEvent(OEHIDEvent *event)
         case OEHIDEventTypeButton :
             ret = [NSString stringWithFormat:@"OEGenericControlButton%ld", [event buttonNumber]];
             break;
+        case OEHIDEventTypeSpecialButton :
+            ret = [NSString stringWithFormat:@"OEGenericSpecialButton%ld", [event buttonNumber]];
+            break;
         case OEHIDEventTypeHatSwitch :
             ret = @"OEGenericControlHatSwitch";
             break;

--- a/OpenEmuSystem/OEControllerDescription.m
+++ b/OpenEmuSystem/OEControllerDescription.m
@@ -261,10 +261,11 @@ OEHIDEventType OEHIDEventTypeFromNSString(NSString *string)
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         namesToValue = @{
-            @"Axis"      : @(OEHIDEventTypeAxis),
-            @"Button"    : @(OEHIDEventTypeButton),
-            @"HatSwitch" : @(OEHIDEventTypeHatSwitch),
-            @"Trigger"   : @(OEHIDEventTypeTrigger),
+            @"Axis"           : @(OEHIDEventTypeAxis),
+            @"Button"         : @(OEHIDEventTypeButton),
+            @"Special Button" : @(OEHIDEventTypeSpecialButton),
+            @"HatSwitch"      : @(OEHIDEventTypeHatSwitch),
+            @"Trigger"        : @(OEHIDEventTypeTrigger),
         };
     });
 
@@ -276,6 +277,7 @@ NSUInteger OEUsageFromUsageStringWithType(NSString *usageString, OEHIDEventType 
     switch(type)
     {
         case OEHIDEventTypeButton :
+        case OEHIDEventTypeSpecialButton :
             return [usageString integerValue];
         case OEHIDEventTypeAxis :
         case OEHIDEventTypeTrigger :

--- a/OpenEmuSystem/OEHIDDeviceHandler.m
+++ b/OpenEmuSystem/OEHIDDeviceHandler.m
@@ -143,6 +143,10 @@
             dict[@kIOHIDElementUsagePageKey] = @(kHIDPage_Button);
             dict[@kIOHIDElementUsageKey]     = @([anEvent buttonNumber]);
             break;
+        case OEHIDEventTypeSpecialButton :
+            dict[@kIOHIDElementUsagePageKey] = @(kHIDPage_Consumer);
+            dict[@kIOHIDElementUsageKey]     = @([anEvent buttonNumber]);
+            break;
         case OEHIDEventTypeHatSwitch :
             dict[@kIOHIDElementUsagePageKey] = @(kHIDPage_GenericDesktop);
             dict[@kIOHIDElementUsageKey]     = @(kHIDUsage_GD_Hatswitch);

--- a/OpenEmuSystem/OEHIDDeviceParser.m
+++ b/OpenEmuSystem/OEHIDDeviceParser.m
@@ -205,7 +205,7 @@ static BOOL OE_isXboxControllerName(NSString *name)
          __block IOHIDElementRef elem = NULL;
 
          // Find the element for the current description.
-         NSMutableArray *targetArray = type == OEHIDEventTypeButton ? buttonElements : genericDesktopElements;
+         NSMutableArray *targetArray = (type == OEHIDEventTypeButton || type == OEHIDEventTypeSpecialButton) ? buttonElements : genericDesktopElements;
          [targetArray enumerateObjectsUsingBlock:
           ^(id obj, NSUInteger idx, BOOL *stop)
           {
@@ -354,6 +354,7 @@ typedef enum {
                  }
                  break;
              case OEHIDEventTypeButton :
+             case OEHIDEventTypeSpecialButton :
                  block(element, OEParsedTypeButton);
                  break;
              case OEHIDEventTypeHatSwitch :
@@ -380,6 +381,7 @@ typedef enum {
                  axisElementsCount++;
                  break;
              case OEHIDEventTypeButton :
+             case OEHIDEventTypeSpecialButton :
              case OEHIDEventTypeHatSwitch :
                  // If we find a non-axis element, we can just stop the search,
                  // we will need to sort out the axis types later.

--- a/OpenEmuSystem/OEHIDEvent.h
+++ b/OpenEmuSystem/OEHIDEvent.h
@@ -33,12 +33,13 @@
 @class OEDeviceHandler, OEHIDDeviceHandler, OEWiimoteHIDDeviceHandler;
 
 typedef enum _OEHIDEventType : NSUInteger {
-    OEHIDEventTypeAxis      = 1,
+    OEHIDEventTypeAxis          = 1,
     // Only for analogic triggers
-    OEHIDEventTypeTrigger   = 5,
-    OEHIDEventTypeButton    = 2,
-    OEHIDEventTypeHatSwitch = 3,
-	OEHIDEventTypeKeyboard  = 4,
+    OEHIDEventTypeTrigger       = 5,
+    OEHIDEventTypeButton        = 2,
+    OEHIDEventTypeSpecialButton = 6,
+    OEHIDEventTypeHatSwitch     = 3,
+	OEHIDEventTypeKeyboard      = 4,
 } OEHIDEventType;
 
 typedef enum _OEHIDAxis : NSUInteger {

--- a/OpenEmuSystem/OESystemBindings.m
+++ b/OpenEmuSystem/OESystemBindings.m
@@ -884,6 +884,7 @@ NSString *const OEGlobalButtonScreenshot        = @"OEGlobalButtonScreenshot";
     switch([anEvent type])
     {
         case OEHIDEventTypeButton :
+        case OEHIDEventTypeSpecialButton :
         case OEHIDEventTypeTrigger :
         {
             [rawBindings enumerateKeysAndObjectsUsingBlock:

--- a/OpenEmuSystem/OEWiimoteHIDDeviceHandler.m
+++ b/OpenEmuSystem/OEWiimoteHIDDeviceHandler.m
@@ -961,6 +961,8 @@ enum {
                  case OEHIDEventTypeButton :
                      event = [OEHIDEvent buttonEventWithDeviceHandler:nil timestamp:0 buttonNumber:usage state:OEHIDEventStateOn cookie:cookie];
                      break;
+                 case OEHIDEventTypeSpecialButton :
+                     NSAssert(NO, @"A special button on Wiimote?!");
                  case OEHIDEventTypeHatSwitch :
                      NSAssert(NO, @"A hat switch on Wiimote?!");
                      break;


### PR DESCRIPTION
This patch fixes an issue with certain third-party controllers (I discovered this with the Moga Hero Power controller), in which certain button (the "Select" button on this particular controller) get mapped by OS X to be special "Back" and/or "Forward" keys instead of generic controller buttons. This causes the event type to be reported by IOHIDElementGetUsagePage() as kHIDPage_Consumer instead of kHIDPage_Button, which causes OpenEmu not to handle the event and the button to be thus rendered unmappable.

This patch attempts to resolve the issue by defining a new event type, OEHIDEventTypeSpecialButton, which behaves identically to OEHIDEventTypeButton but represents a special system key. An alternative solution could be simply to map the back and forward keys to a normal OEHIDEventTypeButton event, if you feel that that would be more appropriate. This patch does this only for the Back and Forward buttons since enabling everything causes odd issues, such as the controls preference dialog giving very inappropriate results when one of the volume keys is pressed.

This patch was put together rather quickly and should probably be tested. The constant name and description strings also may want to be adjusted as your UI designers see fit.

I hope you find this useful.