### PR TITLE
Fix: hat switch buttons perform wrong actions on third-party controllers

### DIFF
--- a/OpenEmuSystem/OEHIDEvent.m
+++ b/OpenEmuSystem/OEHIDEvent.m
@@ -247,7 +247,10 @@ OEHIDEventType OEHIDEventTypeFromIOHIDElement(IOHIDElementRef elem)
             break;
         }
         case kHIDPage_Consumer :
-            return OEHIDEventTypeButton;
+        case kHIDPage_Simulation :
+        case kHIDPage_VR :
+        case kHIDPage_Sport :
+        case kHIDPage_Game :
         case kHIDPage_Button :
             return OEHIDEventTypeButton;
         case kHIDPage_KeyboardOrKeypad :

--- a/OpenEmuSystem/OESystemBindings.m
+++ b/OpenEmuSystem/OESystemBindings.m
@@ -234,7 +234,7 @@ NSString *const OEGlobalButtonScreenshot        = @"OEGlobalButtonScreenshot";
 
         NSAssert(controlValue != nil, @"Unknown control value for identifier: '%@' associated with key name: '%@'", controlIdentifier, keyName);
 
-        if([event type] == OEHIDEventTypeHatSwitch)
+        if([event type] == OEHIDEventTypeHatSwitch && [keyDesc hatSwitchGroup] != nil)
         {
             // Sync the key direction with the hat switch direction, in case they're different.
             enum { NORTH, EAST, SOUTH, WEST, HAT_COUNT };
@@ -247,11 +247,7 @@ NSString *const OEGlobalButtonScreenshot        = @"OEGlobalButtonScreenshot";
             if(direction & OEHIDEventHatDirectionSouth) currentDir = SOUTH;
             if(direction & OEHIDEventHatDirectionWest)  currentDir = WEST;
             
-            OEKeyBindingDescription *newKeyDesc = [[keyDesc hatSwitchGroup] keys][currentDir];
-            
-            if (newKeyDesc != nil) {
-                keyDesc = newKeyDesc;
-            }
+            keyDesc = [[keyDesc hatSwitchGroup] keys][currentDir];
         }
         
         rawBindings[[self OE_keyIdentifierForKeyDescription:keyDesc event:event]] = controlValue;

--- a/OpenEmuSystem/OESystemBindings.m
+++ b/OpenEmuSystem/OESystemBindings.m
@@ -234,6 +234,22 @@ NSString *const OEGlobalButtonScreenshot        = @"OEGlobalButtonScreenshot";
 
         NSAssert(controlValue != nil, @"Unknown control value for identifier: '%@' associated with key name: '%@'", controlIdentifier, keyName);
 
+        if([event type] == OEHIDEventTypeHatSwitch)
+        {
+            // Sync the key direction with the hat switch direction, in case they're different.
+            enum { NORTH, EAST, SOUTH, WEST, HAT_COUNT };
+            
+            OEHIDEventHatDirection direction  = [event hatDirection];
+            NSUInteger     currentDir = NORTH;
+            
+            if(direction & OEHIDEventHatDirectionNorth) currentDir = NORTH;
+            if(direction & OEHIDEventHatDirectionEast)  currentDir = EAST;
+            if(direction & OEHIDEventHatDirectionSouth) currentDir = SOUTH;
+            if(direction & OEHIDEventHatDirectionWest)  currentDir = WEST;
+            
+            keyDesc = [[keyDesc hatSwitchGroup] keys][currentDir];
+        }
+        
         rawBindings[[self OE_keyIdentifierForKeyDescription:keyDesc event:event]] = controlValue;
     }];
 
@@ -673,7 +689,21 @@ NSString *const OEGlobalButtonScreenshot        = @"OEGlobalButtonScreenshot";
             break;
         case OEHIDEventTypeHatSwitch :
             if([keyDesc hatSwitchGroup] != nil)
-                keyDesc = [[keyDesc hatSwitchGroup] orientedKeyGroupWithBaseKey:keyDesc];
+            {
+                OEKeyBindingGroupDescription *hatSwitchGroup = [keyDesc hatSwitchGroup];
+                
+                // Sync the key direction with the hat switch direction, in case they're different.
+                enum { NORTH, EAST, SOUTH, WEST, HAT_COUNT };
+                OEHIDEventHatDirection direction  = [anEvent hatDirection];
+                NSUInteger     currentDir = NORTH;
+                
+                if(direction & OEHIDEventHatDirectionNorth) currentDir = NORTH;
+                if(direction & OEHIDEventHatDirectionEast)  currentDir = EAST;
+                if(direction & OEHIDEventHatDirectionSouth) currentDir = SOUTH;
+                if(direction & OEHIDEventHatDirectionWest)  currentDir = WEST;
+                
+                keyDesc = [hatSwitchGroup orientedKeyGroupWithBaseKey:hatSwitchGroup.keys[currentDir]];
+            }
             break;
         default :
             break;

--- a/OpenEmuSystem/OESystemBindings.m
+++ b/OpenEmuSystem/OESystemBindings.m
@@ -247,7 +247,11 @@ NSString *const OEGlobalButtonScreenshot        = @"OEGlobalButtonScreenshot";
             if(direction & OEHIDEventHatDirectionSouth) currentDir = SOUTH;
             if(direction & OEHIDEventHatDirectionWest)  currentDir = WEST;
             
-            keyDesc = [[keyDesc hatSwitchGroup] keys][currentDir];
+            OEKeyBindingDescription *newKeyDesc = [[keyDesc hatSwitchGroup] keys][currentDir];
+            
+            if (newKeyDesc != nil) {
+                keyDesc = newKeyDesc;
+            }
         }
         
         rawBindings[[self OE_keyIdentifierForKeyDescription:keyDesc event:event]] = controlValue;


### PR DESCRIPTION
Hello,

This patch is to fix a regression in OpenEmu 2.0.1 which causes the button presses for the hat switch to be mapped to the incorrect virtual buttons. The issue is a little difficult to explain, and a video demonstrates it more clearly:

http://charlessoft.com/extraneous_stuff/hat_switch_error.mp4

Basically, there are multiple ways the hat switch can be configured, with the "up" button on the external controller possibly corresponding to "up" on the virtual D-pad, but these can also be out of sync, with "up" on the controller performing a "down" action in the emulator. Unfortunately, although this conceptual differentiation exists, it is not serialized, with the oedefaults file storing only a reference to the hat switch itself, rather than the direction of the event.

I have fixed this simply by synchronizing the event with the key description whenever the controls for the hat switch are changed. Setting the hat switch as a control for the D-pad should always set the "Up" button on the controller as the "Up" button for the D-pad. The same check is done when deserializing the bindings from the file. This seems in line with the way other emulators work (Bannister's old emulators, for example, simply bind the D-pad directions to the hat switch rather than to specific directions on it).

I've also added support for a few more HID pages. The main purpose of this was to enable the L2 and R2 buttons on my Moga Hero controller, which fall under kHIDPage_Simulation, but I've also enabled the VR, Sport, and Game pages, because they could conceivably be desirable for a game app such as this.

I hope you find this useful.