### PR TITLE
Fix issue that caused some Bluetooth mice to break the input system

### DIFF
--- a/OpenEmuSystem/OEHIDEvent.m
+++ b/OpenEmuSystem/OEHIDEvent.m
@@ -662,6 +662,10 @@ static CGEventSourceRef _keyboardEventSource;
     _cookie = (uint32_t)IOHIDElementGetCookie(anElement);
     _type = OEHIDEventTypeFromIOHIDElement(anElement);
 
+    if([self OE_elementRepresentsMouseEvent:anElement]) {
+        return NO;
+    }
+    
     switch(_type)
     {
         case OEHIDEventTypeAxis :
@@ -685,6 +689,19 @@ static CGEventSourceRef _keyboardEventSource;
             return YES;
     }
 
+    return NO;
+}
+
+- (BOOL)OE_elementRepresentsMouseEvent:(IOHIDElementRef)anElement {
+    for(IOHIDElementRef element = anElement; element != NULL; element = IOHIDElementGetParent(element)) {
+        uint32_t usagePage = IOHIDElementGetUsagePage(element);
+        uint32_t usage = IOHIDElementGetUsage(element);
+        
+        if(usagePage == kHIDPage_GenericDesktop && usage == kHIDUsage_GD_Mouse) {
+            return YES;
+        }
+    }
+    
     return NO;
 }
 


### PR DESCRIPTION
I have discovered a bug which can cause certain Bluetooth mouse to make OpenEmu's input handling system go haywire:

http://www.charlessoft.com/extraneous_stuff/mouse_bug.mp4

The bug seems to stem from certain mice (such as my Logitech MX Anywhere 2, for which I've attached an HID profile) claiming to support keyboard usages, for reasons I don't fully understand. This causes IOHIDDeviceConformsTo() to return true for kHIDUsage_GD_Keyboard, causing OpenEmu to think the mouse is a keyboard (and thus to try to handle events from it). When a mouse button is clicked, the system attempts to handle it, although as a button event, it gets a type of OEHIDEventTypeButton, not OEHIDEventTypeKeyboard. -[OEPrefControlsController OE_setCurrentBindingsForEvent:] therefore tries to use it to set the selected player on line 596 of OEPrefControlsController.mm, but _devicePlayerBindings is empty on OESystemBindings.mm line 376, so -[OESystemBindings playerNumberForEvent:] returns 0. This causes OEPrefControlsController's selectedPlayer property to be set to zero, which causes the whole input UI to go haywire.

The solution I've chosen is to look at the event as it comes in from the HID system, see if either it or any of its parent events is a mouse event, and ignore the event if it is. This also causes mouse movement to no longer generate a flurry of events through the system, so there may be a slight performance improvement as well.

I hope you find this patch helpful.

[MX Anywhere 2.plist.zip](https://github.com/OpenEmu/OpenEmu-SDK/files/368072/MX.Anywhere.2.plist.zip)

