### PR TITLE
Adjust default calibration for the Wii U Pro Controller

### DIFF
--- a/OpenEmuSystem/OEWiimoteHIDDeviceHandler.m
+++ b/OpenEmuSystem/OEWiimoteHIDDeviceHandler.m
@@ -144,9 +144,9 @@ static const OEHIDEventAxis OEWiimoteClassicControllerRightTriggerAxisUsage   = 
 typedef enum {
     OEWiimoteProControllerJoystickMinimumValue = 1155,
     OEWiimoteProControllerJoystickMaximumValue = 2955,
-    OEWiimoteProControllerDeadZone = 200,
-    OEWiimoteProControllerJoystickScaledMinimumValue = -900 + OEWiimoteProControllerDeadZone,
-    OEWiimoteProControllerJoystickScaledMaximumValue = -OEWiimoteProControllerJoystickScaledMinimumValue,
+    OEWiimoteProControllerDeadZone = 200,  /* the dead zone is removed from the scaled range! */
+    OEWiimoteProControllerJoystickScaledMinimumValue = -700,
+    OEWiimoteProControllerJoystickScaledMaximumValue = 700,
 
     OEWiimoteProControllerLeftJoystickAxisXCookie   = 0x1000,
     OEWiimoteProControllerLeftJoystickAxisYCookie   = 0x2000,
@@ -819,7 +819,7 @@ enum {
 
         NSInteger ret = value;
         ret -= OEWiimoteProControllerJoystickMinimumValue;
-        ret += OEWiimoteProControllerJoystickScaledMinimumValue;
+        ret += OEWiimoteProControllerJoystickScaledMinimumValue + (-OEWiimoteProControllerDeadZone);
 
         if (-OEWiimoteProControllerDeadZone < ret && ret <= OEWiimoteProControllerDeadZone)
           ret = 0;

--- a/OpenEmuSystem/OEWiimoteHIDDeviceHandler.m
+++ b/OpenEmuSystem/OEWiimoteHIDDeviceHandler.m
@@ -142,11 +142,11 @@ static const OEHIDEventAxis OEWiimoteClassicControllerLeftTriggerAxisUsage    = 
 static const OEHIDEventAxis OEWiimoteClassicControllerRightTriggerAxisUsage   = OEHIDEventAxisRz;
 
 typedef enum {
-    OEWiimoteProControllerJoystickMinimumValue = 900,
-    OEWiimoteProControllerJoystickMaximumValue = 3400,
-    OEWiimoteProControllerDeadZone = 256,
-    OEWiimoteProControllerJoystickScaledMinimumValue = -1250,
-    OEWiimoteProControllerJoystickScaledMaximumValue = 1250,
+    OEWiimoteProControllerJoystickMinimumValue = 1155,
+    OEWiimoteProControllerJoystickMaximumValue = 2955,
+    OEWiimoteProControllerDeadZone = 200,
+    OEWiimoteProControllerJoystickScaledMinimumValue = -900 + OEWiimoteProControllerDeadZone,
+    OEWiimoteProControllerJoystickScaledMaximumValue = -OEWiimoteProControllerJoystickScaledMinimumValue,
 
     OEWiimoteProControllerLeftJoystickAxisXCookie   = 0x1000,
     OEWiimoteProControllerLeftJoystickAxisYCookie   = 0x2000,
@@ -821,7 +821,15 @@ enum {
         ret -= OEWiimoteProControllerJoystickMinimumValue;
         ret += OEWiimoteProControllerJoystickScaledMinimumValue;
 
-        if(-OEWiimoteProControllerDeadZone < ret && ret <= OEWiimoteProControllerDeadZone) ret = 0;
+        if (-OEWiimoteProControllerDeadZone < ret && ret <= OEWiimoteProControllerDeadZone)
+          ret = 0;
+      
+        /* since we use a really big center dead zone, we remove it from the
+         * reported data, to make it possible to input small movements. */
+        if (ret < 0)
+          ret += OEWiimoteProControllerDeadZone;
+        else if (ret > 0)
+          ret -= OEWiimoteProControllerDeadZone;
 
         return ret;
     };


### PR DESCRIPTION
As discussed in issue OpenEmu/OpenEmu#3102, this PR adjusts the calibration parameters for the Wii U Pro Controller to better match the data returned by the controller.