### PR TITLE
Fixed bug when changing oposite direction of usb gamepad/joystick fast

### DIFF
--- a/OpenEmuSystem/OEHIDEvent.m
+++ b/OpenEmuSystem/OEHIDEvent.m
@@ -1423,7 +1423,10 @@ static NSString *OEHIDEventIsFunctionPressedKey  = @"OEHIDEventIsFunctionPressed
     OEHIDEvent *event = [self copy];
 
     event->_data.hatSwitch.hatDirection = aDirection;
-
+ 
+    if(aDirection == OEHIDEventAxisDirectionNull)
+        event->_data.axis.value = 0;
+ 
     return event;
 }
 

--- a/OpenEmuSystem/OEHIDEvent.m
+++ b/OpenEmuSystem/OEHIDEvent.m
@@ -1426,7 +1426,7 @@ static NSString *OEHIDEventIsFunctionPressedKey  = @"OEHIDEventIsFunctionPressed
     OEHIDEvent *event = [self copy];
 
     event->_data.hatSwitch.hatDirection = aDirection;
- 
+
     return event;
 }
 

--- a/OpenEmuSystem/OEHIDEvent.m
+++ b/OpenEmuSystem/OEHIDEvent.m
@@ -1411,6 +1411,9 @@ static NSString *OEHIDEventIsFunctionPressedKey  = @"OEHIDEventIsFunctionPressed
     OEHIDEvent *event = [self copy];
 
     event->_data.axis.direction = aDirection;
+ 
+    if(aDirection == OEHIDEventAxisDirectionNull)
+        event->_data.axis.value = 0;
 
     return event;
 }
@@ -1423,9 +1426,6 @@ static NSString *OEHIDEventIsFunctionPressedKey  = @"OEHIDEventIsFunctionPressed
     OEHIDEvent *event = [self copy];
 
     event->_data.hatSwitch.hatDirection = aDirection;
- 
-    if(aDirection == OEHIDEventAxisDirectionNull)
-        event->_data.axis.value = 0;
  
     return event;
 }


### PR DESCRIPTION
The bug: when changing the direction of usb gamepad/joystick fast on oposite directions (left to right or right to left), one of the direction "sticks" even after the physical directional pad is set to neutral (the character in the game keeps moving on one of the directions.) 

Seems to happen on any console (tested with 2d platform games on nes, snes, and psx) 

Tested with 2 different usb controllers.

The current code already considers this scenario, but it fails to fix the problem. The code on 

OEHIDDeviceHandler.m > - (void)dispatchEvent:(OEHIDEvent *)event {
...

    if([event isAxisDirectionOppositeToEvent:existingEvent]) {
        [[OEDeviceManager sharedDeviceManager] deviceHandler:self didReceiveEvent:[event axisEventWithDirection:OEHIDEventAxisDirectionNull]];
    }

...

}


already watches out for this condition, but fails to actually fix the problem. This code watches out for an axis event that is preceded with another axis event that has an opposite value (so if the new event is "right", the previous event was "left"), then makes sure to first send an axis event with a null value, to nullify the effects of the previous directional event first, then send this newly received directional event. But this current code does not seem to actually nullify the previous directional event.

The fix: adding this line to OEHIDEvent.m > - (instancetype)axisEventWithDirection:(OEHIDEventAxisDirection)aDirection {

....

if(aDirection == OEHIDEventAxisDirectionNull)
        event->_data.axis.value = 0;

...

}

seems to fix the problem. All i'm doing is telling the newly created directional event to also have a value of zero if the direction of the event is null.


(this is my first time contributing to any github project, so please understand if i'm doing something wrong)

using MAC os 10.13.5 high sierra