### PR TITLE
Automatically calibrate analog axes

### DIFF
--- a/OpenEmuSystem/OEDeviceHandler.h
+++ b/OpenEmuSystem/OEDeviceHandler.h
@@ -85,7 +85,7 @@ extern NSString *const OEDeviceHandlerPlaceholderOriginalDeviceDidBecomeAvailabl
 - (CGFloat)deadZoneForControlDescription:(OEControlDescription *)controlDesc;
 - (void)setDeadZone:(CGFloat)deadZone forControlDescription:(OEControlDescription *)controlDesc;
 
-- (CGFloat)scaledValue:(CGFloat)rawValue forAxis:(OEHIDEventAxis)axis controlCookie:(NSUInteger)cookie;
+- (CGFloat)scaledValue:(CGFloat)rawValue forAxis:(OEHIDEventAxis)axis controlCookie:(NSUInteger)cookie withMiddle:(CGFloat)middle;
 
 @end
 

--- a/OpenEmuSystem/OEHIDEvent.m
+++ b/OpenEmuSystem/OEHIDEvent.m
@@ -741,13 +741,15 @@ static CGEventSourceRef _keyboardEventSource;
     {
         case OEHIDEventTypeAxis :
         {
+            NSInteger min = IOHIDElementGetLogicalMin(elem);
+            NSInteger max = IOHIDElementGetLogicalMax(elem);
             CGFloat deadZone = [aDeviceHandler deadZoneForControlCookie:_cookie];
-            CGFloat scaledValue = [aDeviceHandler scaledValue:value forAxis:_data.axis.axis controlCookie:_cookie];
+            CGFloat scaledValue = [aDeviceHandler scaledValue:value forAxis:_data.axis.axis controlCookie:_cookie withMiddle:(min+max)/2+1];
             if (scaledValue < -1.001 || scaledValue > 1.001) {
                 /* device handler does not handle scaling */
-                scaledValue = _OEScaledValueForAxis(IOHIDElementGetLogicalMin(elem),
+                scaledValue = _OEScaledValueForAxis(min,
                                                     value,
-                                                    IOHIDElementGetLogicalMax(elem));
+                                                    max);
             }
 
             if(-deadZone <= scaledValue && scaledValue <= deadZone)

--- a/OpenEmuSystem/OESwitchProControllerHIDDeviceHandler.m
+++ b/OpenEmuSystem/OESwitchProControllerHIDDeviceHandler.m
@@ -462,7 +462,7 @@ static OEHACProControllerStickCalibration OEHACConvertCalibration(
 }
 
 
-- (CGFloat)scaledValue:(CGFloat)rawValue forAxis:(OEHIDEventAxis)axis controlCookie:(NSUInteger)cookie
+- (CGFloat)scaledValue:(CGFloat)rawValue forAxis:(OEHIDEventAxis)axis controlCookie:(NSUInteger)cookie withMiddle:(CGFloat)middle
 {
     OEHACProControllerAxisCalibration *selectedCalibration;
     switch (axis) {
@@ -587,14 +587,14 @@ static OEHACProControllerStickCalibration OEHACConvertCalibration(
     OEHIDEvent *event;
     
     cookie = [OESwitchProControllerHIDDeviceParser _cookieFromUsage:xaxis];
-    value = [self scaledValue:stickData.x forAxis:xaxis controlCookie:cookie];
+    value = [self scaledValue:stickData.x forAxis:xaxis controlCookie:cookie withMiddle:0];
     if (fabs(value) < [self deadZoneForControlCookie:cookie])
         value = 0;
     event = [OEHIDEvent axisEventWithDeviceHandler:self timestamp:now axis:xaxis value:value cookie:cookie];
     [self dispatchEvent:event];
     
     cookie = [OESwitchProControllerHIDDeviceParser _cookieFromUsage:yaxis];
-    value = [self scaledValue:stickData.y forAxis:yaxis controlCookie:cookie];
+    value = [self scaledValue:stickData.y forAxis:yaxis controlCookie:cookie withMiddle:0];
     if (fabs(value) < [self deadZoneForControlCookie:cookie])
         value = 0;
     event = [OEHIDEvent axisEventWithDeviceHandler:self timestamp:now axis:yaxis value:value cookie:cookie];


### PR DESCRIPTION
This PR modfies `OEDeviceHandler.scaledValue` to automatically calibrate itself as the user uses analog controls on a controller.  This fixes OpenEmu/OpenEmu#1709 and OpenEmu/OpenEmu#1303.

Specifically, the current default scaler for analog axes (in `OEHIDEvent`) assumes that every controller can return the full range of values IOKit expects for that HID class.  If IOKit wants values from 0..255, but your controller's X axis only returns values from 50..200, then you'll only be able to use about 56% of a game character's (or vehicle's) range of motion.  A lot of N64-to-USB adapters behave this way, meaning actual N64 controllers behave very poorly with N64 games.

This patch learns the minimum and maximum values for each axis of each stick of each controller as the user plays the game, and normalizes accordingly.  If the highest value `scaledValue` has seen is 200, then pushing the stick to 200 will return +1.0, rather than +0.56.

Calibration values are not saved.  They are relearned each time the emulator starts.

I have tested this patch with an actual N64 controller (which returns about 49..204) and an SN30Pro (which returns 0..255), with FZero X and Zelda Ocarina of Time.  It works as designed.