### PR TITLE
adds AC Exit and AC Properties to input system

### DIFF
--- a/OpenEmuSystem/OEHIDDeviceParser.m
+++ b/OpenEmuSystem/OEHIDDeviceParser.m
@@ -207,6 +207,8 @@ typedef NS_ENUM(NSInteger, OEElementType) {
         case kHIDUsage_Csmr_ACHome :
         case kHIDUsage_Csmr_ACBack :
         case kHIDUsage_Csmr_ACForward :
+        case kHIDUsage_Csmr_ACExit :
+        case kHIDUsage_Csmr_ACProperties :
             return OEElementTypeConsumer;
 
         case kHIDUsage_Sim_Brake :


### PR DESCRIPTION
Adds the `AC Exit` and `AC Properties` consumer HID usages to the input system.
This will permit the creation of full mapping profiles in the database for the SteelSeries Nimbus+
(and presumably other game controllers with those two elements).