### PR TITLE
adds additional detail to console for unaccounted-for detected controller elements

### DIFF
--- a/OpenEmuSystem/OEHIDDeviceParser.m
+++ b/OpenEmuSystem/OEHIDDeviceParser.m
@@ -290,7 +290,7 @@ typedef NS_ENUM(NSInteger, OEElementType) {
         NSLog(@"WARNING: There are %ld generic desktop elements unaccounted for in %@. Details: %@", genericDesktopElements.count, controllerDesc.name, genericDesktopElements.description);
 
     if([buttonElements count] > 0)
-        NSLog(@"WARNING: There are %ld button elements unaccounted for in %@. Details: %@", buttonElements.count, controllerDesc.name, genericDesktopElements.description);
+        NSLog(@"WARNING: There are %ld button elements unaccounted for in %@. Details: %@", buttonElements.count, controllerDesc.name, buttonElements.description);
 
     return attributes;
 }

--- a/OpenEmuSystem/OEHIDDeviceParser.m
+++ b/OpenEmuSystem/OEHIDDeviceParser.m
@@ -287,10 +287,10 @@ typedef NS_ENUM(NSInteger, OEElementType) {
     }]];
 
     if([genericDesktopElements count] > 0)
-        NSLog(@"WARNING: There are %ld generic desktop elements unaccounted for in %@", genericDesktopElements.count, controllerDesc.name);
+        NSLog(@"WARNING: There are %ld generic desktop elements unaccounted for in %@. Details: %@", genericDesktopElements.count, controllerDesc.name, genericDesktopElements.description);
 
     if([buttonElements count] > 0)
-        NSLog(@"WARNING: There are %ld button elements unaccounted for in %@.", buttonElements.count, controllerDesc.name);
+        NSLog(@"WARNING: There are %ld button elements unaccounted for in %@. Details: %@", buttonElements.count, controllerDesc.name, genericDesktopElements.description);
 
     return attributes;
 }

--- a/OpenEmuSystem/OEHIDDeviceParser.m
+++ b/OpenEmuSystem/OEHIDDeviceParser.m
@@ -287,10 +287,10 @@ typedef NS_ENUM(NSInteger, OEElementType) {
     }]];
 
     if([genericDesktopElements count] > 0)
-        NSLog(@"WARNING: There are %ld generic desktop elements unaccounted for in %@. Details: %@", genericDesktopElements.count, controllerDesc.name, genericDesktopElements.description);
+        NSLog(@"WARNING: There are %ld generic desktop elements unaccounted for in %@. List of elements: %@", genericDesktopElements.count, controllerDesc.name, genericDesktopElements.description);
 
     if([buttonElements count] > 0)
-        NSLog(@"WARNING: There are %ld button elements unaccounted for in %@. Details: %@", buttonElements.count, controllerDesc.name, buttonElements.description);
+        NSLog(@"WARNING: There are %ld button elements unaccounted for in %@. List of elements: %@", buttonElements.count, controllerDesc.name, buttonElements.description);
 
     return attributes;
 }

--- a/OpenEmuSystem/OEHIDDeviceParser.m
+++ b/OpenEmuSystem/OEHIDDeviceParser.m
@@ -286,11 +286,17 @@ typedef NS_ENUM(NSInteger, OEElementType) {
         return [OEHIDEvent OE_eventWithElement:(__bridge IOHIDElementRef)elem value:0] == nil;
     }]];
 
-    if([genericDesktopElements count] > 0)
-        NSLog(@"WARNING: There are %ld generic desktop elements unaccounted for in %@. List of elements: %@", genericDesktopElements.count, controllerDesc.name, genericDesktopElements.description);
+    if([genericDesktopElements count] == 1)
+        NSLog(@"WARNING: There is %ld generic desktop element unaccounted for in %@. Element details: %@", genericDesktopElements.count, controllerDesc.name, genericDesktopElements.description);
+    
+    if([genericDesktopElements count] > 1)
+        NSLog(@"WARNING: There are %ld generic desktop elements unaccounted for in %@. Elements in detail: %@", genericDesktopElements.count, controllerDesc.name, genericDesktopElements.description);
 
-    if([buttonElements count] > 0)
-        NSLog(@"WARNING: There are %ld button elements unaccounted for in %@. List of elements: %@", buttonElements.count, controllerDesc.name, buttonElements.description);
+    if([buttonElements count] == 1)
+        NSLog(@"WARNING: There is %ld button element unaccounted for in %@. Element details: %@", buttonElements.count, controllerDesc.name, buttonElements.description);
+    
+    if([buttonElements count] > 1)
+        NSLog(@"WARNING: There are %ld button elements unaccounted for in %@. Elements in detail: %@", buttonElements.count, controllerDesc.name, buttonElements.description);
 
     return attributes;
 }


### PR DESCRIPTION
Small addition to console messages about unaccounted-for elements in controller profiles.
After the initial message with the count and controller name, it provides a line for each each missing element the input system is detecting:

![Screen Shot 2022-06-05 at 7 59 20 PM](https://user-images.githubusercontent.com/17806659/172087372-4085c44b-a88d-4e71-8dec-74a9a4f9639f.png)

I've found it to be helpful for debugging controller profiles I'm creating.